### PR TITLE
Specifies the ORM class instead of the table_name to avoid calling "tabl...

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,15 @@ module TreeRepository
   extend self
   
   @repository = Vorpal.define do
-    map Tree do
+    map Tree, to: ARTree do
       fields :name
       belongs_to :gardener, owned: false
       has_many :branches
     end
 
-    map Gardener
+    map Gardener, to: Gardener
   
-    map Branch do
+    map Branch, to: ARBranch do
       fields :length, :diameter
       belongs_to :tree
     end

--- a/README.md
+++ b/README.md
@@ -108,40 +108,40 @@ require 'vorpal'
 
 module TreeRepository
   extend self
-  
+
+  class TreeDB < ActiveRecord::Base
+    self.table_name = 'trees'
+  end
+
+  class BranchDB < ActiveRecord::Base
+    self.table_name = 'branches'
+  end
+
   @repository = Vorpal.define do
-    map Tree, to: ARTree do
+    map Tree, to: TreeDB do
       fields :name
       belongs_to :gardener, owned: false
       has_many :branches
     end
 
     map Gardener, to: Gardener
-  
-    map Branch, to: ARBranch do
+
+    map Branch, to: BranchDB do
       fields :length, :diameter
       belongs_to :tree
     end
   end
-  
+
   def find(id)
     @repository.load(id, Tree)
   end
-  
+
   def save(tree)
     @repository.persist(tree)
   end
-  
+
   def destroy(tree)
     @repository.destroy(tree)
-  end
-  
-  class ARTree < ActiveRecord::Base
-    self.table_name = 'trees'
-  end
-  
-  class ARBranch < ActiveRecord::Base
-    self.table_name = 'branches'
   end
 end
 ```
@@ -209,7 +209,7 @@ For example:
 
 ```ruby
   def find_all
-    ids = ARTree.pluck(:id) # use an AR query to determine the aggregate ids
+    ids = TreeDB.pluck(:id) # use an AR query to determine the aggregate ids
     @repository.load_all(ids, Tree) # use the repository to load all the aggregates
   end
 ```

--- a/lib/vorpal/config_builder.rb
+++ b/lib/vorpal/config_builder.rb
@@ -77,18 +77,18 @@ class ConfigBuilder
   def build_class_config
     Vorpal::ClassConfig.new(
       domain_class: @domain_class,
-      table_name: @class_options[:table_name] || table_name,
+      db_class: @class_options[:to] || db_class,
       serializer: @class_options[:serializer] || serializer(fields_with_id),
       deserializer: @class_options[:deserializer] || deserializer(fields_with_id),
     )
   end
 
-  def fields_with_id
-    [:id].concat @fields
+  def db_class
+    "#{@domain_class.name}DB".constantize
   end
 
-  def table_name
-    @domain_class.name.tableize
+  def fields_with_id
+    [:id].concat @fields
   end
 
   def build_has_manys

--- a/lib/vorpal/configs.rb
+++ b/lib/vorpal/configs.rb
@@ -39,7 +39,7 @@ end
 
 # @private
 class ClassConfig
-  attr_reader :serializer, :deserializer, :domain_class, :table_name
+  attr_reader :serializer, :deserializer, :domain_class, :db_class
   attr_accessor :has_manys, :belongs_tos, :has_ones
 
   def initialize(attrs)
@@ -55,10 +55,6 @@ class ClassConfig
   def get_primary_keys(count)
     result = ActiveRecord::Base.connection.execute("select nextval('#{sequence_name}') from generate_series(1,#{count});")
     result.column_values(0).map(&:to_i)
-  end
-
-  def db_class
-    @db_class ||= ActiveRecord::Base.descendants.detect { |ar| ar.table_name == table_name }
   end
 
   def find_in_db(object)
@@ -119,7 +115,7 @@ class ClassConfig
   private
 
   def sequence_name
-    "#{table_name}_id_seq"
+    "#{db_class.table_name}_id_seq"
   end
 end
 

--- a/lib/vorpal/configuration.rb
+++ b/lib/vorpal/configuration.rb
@@ -18,8 +18,8 @@ module Configuration
   #
   # @param domain_class [Class] Type of the domain model to be mapped
   # @param options [Hash] Configure how to map the domain model
-  # @option options [String] :table_name (Name of the domain class snake-cased and pluralized.)
-  #   Name of the relational DB table.
+  # @option options [String] :to (Class with the same name as the domain class with a 'DB' appended.)
+  #   Class of the ActiveRecord object that will map this domain class to the DB.
   # @option options [Object] :serializer (map the {ConfigBuilder#fields} directly)
   #   Object that will convert the domain objects into a hash.
   #

--- a/spec/vorpal/aggregate_repository_spec.rb
+++ b/spec/vorpal/aggregate_repository_spec.rb
@@ -643,7 +643,7 @@ private
         belongs_to :environment, owned: false, fk: :environment_id, fk_type: :environment_type, child_class: Swamp
       end
 
-      map Swamp
+      map Swamp, to: Swamp
     end
   end
 
@@ -727,7 +727,7 @@ private
         fields :length
       end
 
-      map Fissure
+      map Fissure, to: Fissure
     end
   end
 


### PR DESCRIPTION
...e_name" on every AR::Base class.
