### PR TITLE
RFC: Remove default order by in db_driver [DO NOT MERGE]

### DIFF
--- a/lib/vorpal/db_driver.rb
+++ b/lib/vorpal/db_driver.rb
@@ -43,7 +43,7 @@ module Vorpal
     def load_by_foreign_key(class_config, id, foreign_key_info)
       arel = class_config.db_class.where(foreign_key_info.fk_column => id)
       arel = arel.where(foreign_key_info.fk_type_column => foreign_key_info.fk_type) if foreign_key_info.polymorphic?
-      arel.order(:id).to_a
+      arel.to_a
     end
 
     # Fetches primary key values to be used for new entities.


### PR DESCRIPTION
@sskirby after our conversation today about built-in ordering, I just want to raise this question - should there be a test to make sure this is enforced? and/or that you can add your own ordering?
