### PR TITLE
Remove executables from gemspec

### DIFF
--- a/vorpal.gemspec
+++ b/vorpal.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Vorpal does not provide any command line executable. Also, the bin directory is for binstub used during development/test of vorpal.

We are getting the following warning after upgrading Ruby/bundler:

```
The `rspec` executable in the `rspec-core` gem is being loaded, but it's also present in other gems (vorpal).
If you meant to run the executable for another gem, make sure you use a project specific binstub (`bundle binstub <gem_name>`).
If you plan to use multiple conflicting executables, generate binstubs for them and disambiguate their names.
```