### PR TITLE
Support models backed by PG updatable views

### DIFF
--- a/lib/vorpal/driver/postgresql.rb
+++ b/lib/vorpal/driver/postgresql.rb
@@ -99,6 +99,7 @@ module Vorpal
 
         db_class.vorpal_model_class_name = Util::StringUtils.escape_class_name(model_class.name)
         db_class.table_name = table_name
+        db_class.primary_key = 'id'
         db_class
       end
 

--- a/spec/acceptance/vorpal/aggregate_mapper_spec.rb
+++ b/spec/acceptance/vorpal/aggregate_mapper_spec.rb
@@ -64,7 +64,8 @@ describe 'AggregateMapper' do
     define_table('branches', {length: :decimal, tree_id: :integer, branch_id: :integer}, false)
     define_table('bugs', {name: :text, lives_on_id: :integer, lives_on_type: :string}, false)
     define_table('fissures', {length: :decimal, tree_id: :integer}, false)
-    define_table('trees', {name: :text, tree_unique_key: :integer, trunk_id: :integer, environment_id: :integer, environment_type: :string}, false)
+    define_table('trees_table', {name: :text, tree_unique_key: :integer, trunk_id: :integer, environment_id: :integer, environment_type: :string}, false)
+    define_updatable_view('trees', 'trees_table')
     define_table('trunks', {trunk_unique_key: :integer, length: :decimal}, false)
     define_table('swamps', {}, false)
   end

--- a/spec/helpers/db_helpers.rb
+++ b/spec/helpers/db_helpers.rb
@@ -47,6 +47,12 @@ module DbHelpers
     end
   end
 
+  def define_updatable_view(view_name, table_name)
+    db_connection.execute(<<~SQL)
+      CREATE OR REPLACE VIEW #{view_name} AS SELECT * FROM #{table_name}
+    SQL
+  end
+
   # Has the same API as the Rails create_table, except doesn't die when the
   # table already exists
   def create_table(table_name, force: nil, **options)


### PR DESCRIPTION
Updatable views are commonly used for ZDT-safe DB migrations, so supporting them out-of-the-box will save work.